### PR TITLE
Fixed a deadlock in CdStream and LoadLibrary path translation heuristics

### DIFF
--- a/include/modloader/gta3/gta3.hpp
+++ b/include/modloader/gta3/gta3.hpp
@@ -79,8 +79,8 @@ namespace modloader
 
     template<uintptr_t addr, class Traits = dtraits::WinCreateFileA>
     using WinCreateFileA = modloader::basic_file_detour<Traits,
-                                                injector::function_hooker_stdcall<addr, HANDLE(LPCTSTR, DWORD, DWORD, LPSECURITY_ATTRIBUTES, DWORD, DWORD, HANDLE)>,
-                                                                                        HANDLE, LPCTSTR, DWORD, DWORD, LPSECURITY_ATTRIBUTES, DWORD, DWORD, HANDLE>;
+                                                injector::function_hooker_stdcall<addr, HANDLE(LPCSTR, DWORD, DWORD, LPSECURITY_ATTRIBUTES, DWORD, DWORD, HANDLE)>,
+                                                                                        HANDLE, LPCSTR, DWORD, DWORD, LPSECURITY_ATTRIBUTES, DWORD, DWORD, HANDLE>;
 
 
     template<uintptr_t addr, class Traits = dtraits::LoadAtomic2Return>

--- a/include/modloader/modloader.h
+++ b/include/modloader/modloader.h
@@ -29,7 +29,7 @@ extern "C" {
 /* Version */
 #define MODLOADER_VERSION_MAJOR         0
 #define MODLOADER_VERSION_MINOR         3
-#define MODLOADER_VERSION_REVISION      6
+#define MODLOADER_VERSION_REVISION      7
 #ifdef NDEBUG
 #define MODLOADER_VERSION_ISDEV         0
 #else

--- a/include/modloader/modloader.h
+++ b/include/modloader/modloader.h
@@ -29,7 +29,7 @@ extern "C" {
 /* Version */
 #define MODLOADER_VERSION_MAJOR         0
 #define MODLOADER_VERSION_MINOR         3
-#define MODLOADER_VERSION_REVISION      5
+#define MODLOADER_VERSION_REVISION      6
 #ifdef NDEBUG
 #define MODLOADER_VERSION_ISDEV         0
 #else

--- a/include/modloader/util/path.hpp
+++ b/include/modloader/util/path.hpp
@@ -311,9 +311,9 @@ namespace modloader
      *      WinAPI-like function to check if a directory exists
      *      @szPath: Directory to check
      */
-    inline BOOL IsDirectoryA(LPCTSTR szPath)
+    inline BOOL IsDirectoryA(LPCSTR szPath)
     {
-      DWORD dwAttrib = GetFileAttributes(szPath);
+      DWORD dwAttrib = GetFileAttributesA(szPath);
       return (dwAttrib != INVALID_FILE_ATTRIBUTES && 
              (dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
     }
@@ -323,7 +323,7 @@ namespace modloader
      *      WinAPI-like function to check if a file or directory exists
      *      @szPath: Directory to check
      */
-    inline BOOL IsPathA(LPCTSTR szPath)
+    inline BOOL IsPathA(LPCSTR szPath)
     {
       DWORD dwAttrib = GetFileAttributesA(szPath);
       return (dwAttrib != INVALID_FILE_ATTRIBUTES);
@@ -352,7 +352,7 @@ namespace modloader
      *      WinAPI-like function to make sure a directory exists, if not, create it
      *      @szPath: Directory to check
      */
-    inline BOOL MakeSureDirectoryExistA(LPCTSTR szPath)
+    inline BOOL MakeSureDirectoryExistA(LPCSTR szPath)
     {
         if(!IsDirectoryA(szPath))
         {
@@ -371,7 +371,7 @@ namespace modloader
      *      WinAPI-like function that copies the full directory @szFrom to @szTo
      *      If @szTo doesn't exist, it is created
      */
-    inline BOOL CopyDirectoryA(LPCTSTR szFrom, LPCTSTR szTo)
+    inline BOOL CopyDirectoryA(LPCSTR szFrom, LPCSTR szTo)
     {
         if(CreateDirectoryA(szTo, NULL))
         {
@@ -403,7 +403,7 @@ namespace modloader
      *  DestroyDirectoryA
      *      WinAPI-like function that deletes the path @szPath fully
      */
-    inline BOOL DestroyDirectoryA(LPCTSTR szPath)
+    inline BOOL DestroyDirectoryA(LPCSTR szPath)
     {
         FilesWalk(szPath, "*.*", false, [&szPath](FileWalkInfo& file)
         {
@@ -429,7 +429,7 @@ namespace modloader
      *  GetFileSize
      *      WinAPI-like function that gets the file size of @szPath
      */
-    inline LONGLONG GetFileSize(LPCTSTR szPath)
+    inline LONGLONG GetFileSize(LPCSTR szPath)
     {
         WIN32_FILE_ATTRIBUTE_DATA fad;
         return GetFileAttributesExA(szPath, GetFileExInfoStandard, &fad)?
@@ -471,7 +471,8 @@ namespace modloader
 
         /* Enter on ctor, Leave on dtor */
         scoped_lock(CRITICAL_SECTION& cs)
-        { c = &cs; EnterCriticalSection(&cs); }
+			: c(&cs)
+		{ EnterCriticalSection(&cs); }
         ~scoped_lock()
         { LeaveCriticalSection(c); }
     };

--- a/src/plugins/gta3/std.asi/args_translator/hacks/FindCleoScripts.hpp
+++ b/src/plugins/gta3/std.asi/args_translator/hacks/FindCleoScripts.hpp
@@ -247,7 +247,7 @@ namespace hacks
      *  Hacked FindFirstFileA
      */
     template<>
-    bool FindCleoScripts::Finder<aFindFirstFileA>(HANDLE& result, LPCTSTR& lpFileName, LPWIN32_FIND_DATAA& lpFindFileData)
+    bool FindCleoScripts::Finder<aFindFirstFileA>(HANDLE& result, LPCSTR& lpFileName, LPWIN32_FIND_DATAA& lpFindFileData)
     {
         char version;
         

--- a/src/plugins/gta3/std.asi/args_translator/translator_basic.hpp
+++ b/src/plugins/gta3/std.asi/args_translator/translator_basic.hpp
@@ -77,6 +77,7 @@ struct path_translator_base
     bool bFindFirstFile;            // ^
     bool bFindNextFile;             // ^
     bool bFindClose;                // ^
+    bool bLoadLibrary;              // ^
     bool bDoBassHack;               // ^
     
     // Almost static vars (he), the value is always the same in all objects
@@ -463,6 +464,7 @@ struct path_translator_basic : public path_translator_base
             bFindFirstFile     = (Symbol == aFindFirstFileA) || (Symbol == aFindFirstFileW);
             bFindNextFile      = (Symbol == aFindNextFileA) || (Symbol == aFindNextFileW);
             bFindClose         = (Symbol == aFindClose);
+            bLoadLibrary	   = (Symbol == aLoadLibraryA) || (Symbol == aLoadLibraryW) || (Symbol == aLoadLibraryExA) || (Symbol == aLoadLibraryExW);
             bIniOperations     = false;
         }
     }

--- a/src/plugins/gta3/std.asi/args_translator/translator_stdcall.hpp
+++ b/src/plugins/gta3/std.asi/args_translator/translator_stdcall.hpp
@@ -72,7 +72,21 @@ struct path_translator_stdcall<Symbol, LibName, Ret(Args...)> : public path_tran
             }
             
             if(!bDetoured)
-                info.TranslateForCall(a...); // Translate the paths
+			{
+				if(info.base->bLoadLibrary)
+				{
+					auto f = (func_type) info.base->fun;
+					result = f(a...);
+					if(result != NULL)
+					{
+						// If DLL loaded without translating the path, abort translation and don't try to call it again
+						bDetoured = true;
+					}
+
+				}
+				if(!bDetoured)
+					info.TranslateForCall(a...); // Translate the paths
+			}
         }
         
         if(!bDetoured)

--- a/src/plugins/gta3/std.stream/backend.cpp
+++ b/src/plugins/gta3/std.stream/backend.cpp
@@ -92,7 +92,7 @@ int __stdcall CdStreamThread()
     // Get reference to the addresses we'll use.
     if(gvm.IsSA())
     {
-        auto& cdinfo = *memory_pointer(0x8E3FEC).get<CdStreamInfoSA>();
+        auto& cdinfo = *memory_pointer(0x8E3FE0).get<CdStreamInfoSA>();
         pSemaphore = &cdinfo.semaphore;
         pQueue = &cdinfo.queue;
         ppStreams = &cdinfo.pStreams;

--- a/src/plugins/gta3/std.stream/backend.cpp
+++ b/src/plugins/gta3/std.stream/backend.cpp
@@ -796,3 +796,12 @@ void CAbstractStreaming::Patch()
     }
 }
 
+/*
+*  Export for SilentPatch so it knows that this ML version patches the race condition
+*/
+extern "C" __declspec(dllexport)
+uint32_t CdStreamRaceConditionAware()
+{
+	return 1;
+}
+

--- a/src/plugins/gta3/std.stream/streaming.cpp
+++ b/src/plugins/gta3/std.stream/streaming.cpp
@@ -6,6 +6,7 @@
  */
 #include <stdinc.hpp>
 #include "streaming.hpp"
+#include "cdstreamsync.inl"
 using namespace modloader;
 
 CAbstractStreaming* streaming;
@@ -17,10 +18,13 @@ CAbstractStreaming* streaming;
 CAbstractStreaming::CAbstractStreaming()
 {
     InitializeCriticalSection(&cs);
+    InitializeCriticalSectionAndSpinCount(&cdStreamSyncLock, 10);
+	cdStreamSyncFuncs = CdStreamSyncFix::InitializeSyncFuncs();
 }
 
 CAbstractStreaming::~CAbstractStreaming()
 {
+    DeleteCriticalSection(&cdStreamSyncLock);
     DeleteCriticalSection(&cs);
     Fastman92LimitAdjusterDestroy(this->f92la);
 }

--- a/src/plugins/gta3/std.stream/streaming.hpp
+++ b/src/plugins/gta3/std.stream/streaming.hpp
@@ -20,6 +20,8 @@
 #include <traits/gta3/vc.hpp>
 #include <traits/gta3/iii.hpp>
 
+#include "cdstreamsync.hpp"
+
 using namespace modloader;
 
 // Streaming file type
@@ -124,6 +126,8 @@ class CAbstractStreaming
     public: // Friends
         template<class T> friend class Refresher;
         friend int __stdcall CdStreamThread();
+		friend void __stdcall CdStreamShutdownSync_Stub( CdStream* stream, size_t idx );
+		friend uint32_t CdStreamSync( int32_t streamID );
 
     private:
         LibF92LA f92la;                             //
@@ -133,6 +137,9 @@ class CAbstractStreaming
         CRITICAL_SECTION cs;                        // This must be used together with imported files list for thread-safety
         std::string fbuffer;                        // File buffer to avoid a dynamic allocation everytime we open a model
         std::list<const modloader::file*> imgFiles; // List of img files imported with Mod Loader
+
+        CRITICAL_SECTION cdStreamSyncLock;			// Used to bugfix a deadlock in CdStream
+		CdStreamSyncFix::SyncFuncs cdStreamSyncFuncs;	// Initialize/Finalize/Sleep/Wake functions for CdStream synchronization
 
     public:
         // Basic types

--- a/src/shared/cdstreamsync.hpp
+++ b/src/shared/cdstreamsync.hpp
@@ -1,0 +1,64 @@
+#pragma once
+#include <windows.h>
+#include "CdStreamInfo.h"
+
+struct CdStream;
+
+namespace CdStreamSyncFix
+{
+	union SyncObj
+	{
+		HANDLE semaphore;
+		CONDITION_VARIABLE cv;
+	};
+
+	struct SyncFuncs
+	{
+		SyncObj (__stdcall* Initialize)();
+		void (__stdcall* Shutdown)( CdStream* stream );
+		void (__stdcall* SleepCS)( CdStream* stream, PCRITICAL_SECTION critSec );
+		void (__stdcall* Wake)( CdStream* stream );
+	};
+
+	namespace Sema
+	{
+		SyncObj __stdcall Initialize();
+		void __stdcall Shutdown( CdStream* stream );
+		void __stdcall SleepCS( CdStream* stream, PCRITICAL_SECTION critSec );
+		void __stdcall Wake( CdStream* stream );
+	}
+
+	namespace CV
+	{
+		SyncObj __stdcall Initialize();
+		void __stdcall Shutdown( CdStream* stream );
+		void __stdcall SleepCS( CdStream* stream, PCRITICAL_SECTION critSec );
+		void __stdcall Wake( CdStream* stream );
+	}
+
+	bool TryInitCV();
+
+	inline SyncFuncs InitializeSyncFuncs()
+	{
+		SyncFuncs funcs;
+		if ( TryInitCV() )
+		{
+			using namespace CV;
+			funcs.Initialize = Initialize;
+			funcs.Shutdown = Shutdown;
+			funcs.SleepCS = SleepCS;
+			funcs.Wake = Wake;
+		}
+		else
+		{
+			using namespace Sema;
+			funcs.Initialize = Initialize;
+			funcs.Shutdown = Shutdown;
+			funcs.SleepCS = SleepCS;
+			funcs.Wake = Wake;
+		}
+		return funcs;
+	}
+}
+
+static_assert(sizeof(CdStreamSyncFix::SyncObj) == sizeof(HANDLE), "Incorrect struct size: CdStreamSync::SyncObj");

--- a/src/shared/cdstreamsync.inl
+++ b/src/shared/cdstreamsync.inl
@@ -1,0 +1,83 @@
+#pragma once
+#include "cdstreamsync.hpp"
+
+namespace CdStreamSyncFix
+{
+	namespace Sema
+	{
+		inline SyncObj __stdcall Initialize()
+		{
+			SyncObj object;
+			object.semaphore = CreateSemaphore( nullptr, 0, 2, nullptr );
+			return object;
+		}
+
+		inline void __stdcall Shutdown( CdStream* stream )
+		{
+			CloseHandle( stream->sync.semaphore );
+		}
+
+		inline void __stdcall SleepCS( CdStream* stream, PCRITICAL_SECTION critSec )
+		{
+			if ( stream->nSectorsToRead != 0 )
+			{
+				stream->bLocked = 1;
+				LeaveCriticalSection( critSec );
+				WaitForSingleObject( stream->sync.semaphore, INFINITE );
+				EnterCriticalSection( critSec );
+			}
+		}
+
+		inline void __stdcall Wake( CdStream* stream )
+		{
+			if( stream->bLocked ) ReleaseSemaphore( stream->sync.semaphore, 1, nullptr );
+		}
+	}
+
+	namespace CV
+	{
+		namespace Funcs
+		{
+			static decltype(InitializeConditionVariable)* pInitializeConditionVariable = nullptr;
+			static decltype(SleepConditionVariableCS)* pSleepConditionVariableCS = nullptr;
+			static decltype(WakeConditionVariable)* pWakeConditionVariable = nullptr;
+		}
+
+		inline SyncObj __stdcall Initialize()
+		{
+			SyncObj object;
+			Funcs::pInitializeConditionVariable( &object.cv );
+			return object;
+		}
+
+		inline void __stdcall Shutdown( CdStream* stream )
+		{
+		}
+
+		inline void __stdcall SleepCS( CdStream* stream, PCRITICAL_SECTION critSec )
+		{
+			while ( stream->nSectorsToRead != 0 )
+			{
+				Funcs::pSleepConditionVariableCS( &stream->sync.cv, critSec, INFINITE );
+			}
+		}
+
+		inline void __stdcall Wake( CdStream* stream )
+		{
+			Funcs::pWakeConditionVariable( &stream->sync.cv );
+		}
+	}
+
+	bool TryInitCV()
+	{
+		const HMODULE kernelDLL = GetModuleHandle( TEXT("kernel32") );
+		assert( kernelDLL != nullptr );
+
+		using namespace CV::Funcs;
+		pInitializeConditionVariable = (decltype(pInitializeConditionVariable))GetProcAddress( kernelDLL, "InitializeConditionVariable" );
+		pSleepConditionVariableCS = (decltype(pSleepConditionVariableCS))GetProcAddress( kernelDLL, "SleepConditionVariableCS" );
+		pWakeConditionVariable = (decltype(pWakeConditionVariable))GetProcAddress( kernelDLL, "WakeConditionVariable" );
+
+		return pInitializeConditionVariable != nullptr && pSleepConditionVariableCS != nullptr && pWakeConditionVariable != nullptr;
+	}
+}

--- a/src/shared/game/gta3/CdStreamInfo.h
+++ b/src/shared/game/gta3/CdStreamInfo.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <windows.h>
 #include "Queue.h"
+#include "cdstreamsync.hpp"
 
 struct CdStream	// sizeof = 0x30
 {
@@ -12,7 +13,7 @@ struct CdStream	// sizeof = 0x30
 	BYTE bInUse;
 	BYTE field_F;
 	DWORD status;
-	HANDLE semaphore;
+	CdStreamSyncFix::SyncObj sync;
 	HANDLE hFile;
 	OVERLAPPED overlapped;
 };
@@ -41,4 +42,3 @@ struct CdStreamInfoSA	// sizeof = 0x8CC
 
 static_assert(sizeof(CdStreamInfoSA) == 0x8CC, "Incorrect struct size: CdStreamInfoSA");
 static_assert(sizeof(CdStream) == 0x30, "Incorrect struct size: CdStream");
-

--- a/src/shared/game/gta3/CdStreamInfo.h
+++ b/src/shared/game/gta3/CdStreamInfo.h
@@ -2,7 +2,6 @@
 #include <windows.h>
 #include "Queue.h"
 
-#pragma pack(push, 1)
 struct CdStream	// sizeof = 0x30
 {
 	DWORD nSectorOffset;
@@ -17,9 +16,7 @@ struct CdStream	// sizeof = 0x30
 	HANDLE hFile;
 	OVERLAPPED overlapped;
 };
-#pragma pack(pop)
 
-#pragma pack(push, 1)
 struct CdStreamInfoSA	// sizeof = 0x8C0
 {
 	Queue queue;
@@ -38,7 +35,6 @@ struct CdStreamInfoSA	// sizeof = 0x8C0
 	DWORD gtaint_id;
 	DWORD gta3_id;
 };
-#pragma pack(pop)
 
 static_assert(sizeof(CdStreamInfoSA) == 0x8C0, "Incorrect struct size: CdStreamInfoSA");
 static_assert(sizeof(CdStream) == 0x30, "Incorrect struct size: CdStream");

--- a/src/shared/game/gta3/CdStreamInfo.h
+++ b/src/shared/game/gta3/CdStreamInfo.h
@@ -17,8 +17,11 @@ struct CdStream	// sizeof = 0x30
 	OVERLAPPED overlapped;
 };
 
-struct CdStreamInfoSA	// sizeof = 0x8C0
+struct CdStreamInfoSA	// sizeof = 0x8CC
 {
+	DWORD streamCreateFlags;
+	BOOL streamingInitialized;
+	BOOL overlappedIO;
 	Queue queue;
 	CdStream* pStreams;
 	DWORD thread_id;
@@ -36,6 +39,6 @@ struct CdStreamInfoSA	// sizeof = 0x8C0
 	DWORD gta3_id;
 };
 
-static_assert(sizeof(CdStreamInfoSA) == 0x8C0, "Incorrect struct size: CdStreamInfoSA");
+static_assert(sizeof(CdStreamInfoSA) == 0x8CC, "Incorrect struct size: CdStreamInfoSA");
 static_assert(sizeof(CdStream) == 0x30, "Incorrect struct size: CdStream");
 

--- a/src/translator/gta3/3/10.hpp
+++ b/src/translator/gta3/3/10.hpp
@@ -118,6 +118,8 @@ static void III_10(std::map<memory_pointer_raw, memory_pointer_raw>& map)
         map[xVc(0x6F76F4)] = 0x62129C; // HANDLE hCdSemaphore
         map[xVc(0x6F7700)] = 0x6212A8; // Queue CdQueue;
         map[xVc(0x6F76FC)] = 0x6212A4; // CdStream* channelFile
+        map[xVc(0x6F7718)] = 0x6212C0; // BOOL streamingInitialized
+        map[xVc(0x6F7714)] = 0x6212BC; // BOOL overlappedIO
         map[0x8E4CAC] = 0x87F818;   // void* CStreaming::ms_pStreamingBuffer[2]
         map[0x8E4CA8] = 0x942FB0;   // unsigned int CStreaming::ms_streamingBufferSize
 
@@ -154,6 +156,11 @@ static void III_10(std::map<memory_pointer_raw, memory_pointer_raw>& map)
         map[xIII(0x4038FC)] = 0x4038FC;   // call    __loadIfp    ; @CAnimManager::LoadAnimFiles "anim/ped.ifp"
         map[0x40E2C5] = 0x40A571;   // call    _ZN10CStreaming21ConvertBufferToObjectEPcii
         map[0x40E1BE] = 0x40A585;   // call    _ZN10CStreaming22FinishLoadingLargeFileEPci
+        map[xVc(0x4088F7)] = 0x405B67;	// loc_4088F7
+        map[xVc(0x4088F7) + 10] = 0x405B67 + 10;  // call    ds:CreateSemaphoreA
+        map[xVc(0x4088F7) + 0x22] = 0x405B67 + 0x22;	// jnz     short loc_408930
+        map[xVc(0x4086B6)] = 0x405E16;	// mov     eax, [ecx+ebp+14h]
+        map[0x406460] = 0x406010;	// _Z12CdStreamSynci
 
         map[0xB74490] = 0x8F2C60;   // CPool<> *CPools::ms_pPedPool
         map[0xB74494] = 0x9430DC;   // CPool<> *CPools::ms_pVehiclePool

--- a/src/translator/gta3/sa/10us.hpp
+++ b/src/translator/gta3/sa/10us.hpp
@@ -141,7 +141,7 @@ static void sa_10us(std::map<memory_pointer_raw, memory_pointer_raw>& map)
         map[0x40E2C5] = 0x40E2C5;   // call    _ZN10CStreaming21ConvertBufferToObjectEPcii
         map[0x40E1BE] = 0x40E1BE;   // call    _ZN10CStreaming22FinishLoadingLargeFileEPci
         map[0x406910] = 0x406910;	// loc_406910
-        map[0x406926] = 0x406926;	// jz      short loc_406995
+        map[0x406910 + 0x16] = 0x406910 + 0x16;	// jz      short loc_406995
         map[0x4063B5] = 0x4063B5;	// loc_4063B0
         map[0x406460] = 0x406460;	// _Z12CdStreamSynci
 

--- a/src/translator/gta3/sa/10us.hpp
+++ b/src/translator/gta3/sa/10us.hpp
@@ -105,8 +105,7 @@ static void sa_10us(std::map<memory_pointer_raw, memory_pointer_raw>& map)
         map[0x5A419B] = 0x5A419B;   // -> offset clothesDirectory
         map[0x5B8AFC] = 0x5B8AFC;   // -> &ms_aInfoForModel[MAX_INFO_FOR_MODEL]
 
-        map[0x8E3FE0] = 0x8E3FE0;   // DWORD StreamCreateFlags
-        map[0x8E3FEC] = 0x8E3FEC;   // CdStreamInfo cdinfo
+        map[0x8E3FE0] = 0x8E3FE0;   // DWORD StreamCreateFlags and CdStreamInfo cdinfo
         map[0x8E4CAC] = 0x8E4CAC;   // void* CStreaming::ms_pStreamingBuffer[2]
         map[0x8E4CA8] = 0x8E4CA8;   // unsigned int CStreaming::ms_streamingBufferSize
 

--- a/src/translator/gta3/sa/10us.hpp
+++ b/src/translator/gta3/sa/10us.hpp
@@ -140,6 +140,10 @@ static void sa_10us(std::map<memory_pointer_raw, memory_pointer_raw>& map)
         map[0x4D565A] = 0x4D565A;   // call    _RwStreamOpen    ; @CAnimManager::LoadAnimFiles "anim/ped.ifp"
         map[0x40E2C5] = 0x40E2C5;   // call    _ZN10CStreaming21ConvertBufferToObjectEPcii
         map[0x40E1BE] = 0x40E1BE;   // call    _ZN10CStreaming22FinishLoadingLargeFileEPci
+        map[0x406910] = 0x406910;	// loc_406910
+        map[0x406926] = 0x406926;	// jz      short loc_406995
+        map[0x4063B5] = 0x4063B5;	// loc_4063B0
+        map[0x406460] = 0x406460;	// _Z12CdStreamSynci
 
         map[0xB74490] = 0xB74490;   // CPool<> *CPools::ms_pPedPool
         map[0xB74494] = 0xB74494;   // CPool<> *CPools::ms_pVehiclePool

--- a/src/translator/gta3/vc/10.hpp
+++ b/src/translator/gta3/vc/10.hpp
@@ -163,6 +163,8 @@ static void vc_10(std::map<memory_pointer_raw, memory_pointer_raw>& map)
         map[xVc(0x6F76F4)] = 0x6F76F4; // HANDLE hCdSemaphore
         map[xVc(0x6F7700)] = 0x6F7700; // Queue CdQueue;
         map[xVc(0x6F76FC)] = 0x6F76FC; // CdStream* channelFile
+        map[xVc(0x6F7718)] = 0x6F7718; // BOOL streamingInitialized
+        map[xVc(0x6F7714)] = 0x6F7714; // BOOL overlappedIO
         map[0x8E4CAC] = 0x94B840;   // void* CStreaming::ms_pStreamingBuffer[2]
         map[0x8E4CA8] = 0xA0FC90;   // unsigned int CStreaming::ms_streamingBufferSize
  
@@ -201,6 +203,11 @@ static void vc_10(std::map<memory_pointer_raw, memory_pointer_raw>& map)
         map[0x4D565A] = 0x4055EA;   // call    _RwStreamOpen    ; @CAnimManager::LoadAnimFiles "anim/ped.ifp"
         map[0x40E2C5] = 0x40C086;   // call    _ZN10CStreaming21ConvertBufferToObjectEPcii
         map[0x40E1BE] = 0x40BF0B;   // call    _ZN10CStreaming22FinishLoadingLargeFileEPci
+        map[xVc(0x4088F7)] = 0x4088F7;	// loc_4088F7
+        map[xVc(0x4088F7) + 10] = 0x4088F7 + 10;  // call    ds:CreateSemaphoreA
+        map[xVc(0x4088F7) + 0x22] = 0x4088F7 + 0x22;	// jnz     short loc_408930
+        map[xVc(0x4086B6)] = 0x4086B6;	// mov     eax, [ecx+ebp+14h]
+        map[0x406460] = 0x4083D0;	// _Z12CdStreamSynci
  
         map[0xB74490] = 0x97F2AC;   // CPool<> *CPools::ms_pPedPool
         map[0xB74494] = 0xA0FDE4;   // CPool<> *CPools::ms_pVehiclePool


### PR DESCRIPTION
This PR introduces two bugfixes:

- Fixed an original game bug causing CdStreamSync to deadlock randomly (included an export for other mods to check if this std.stream build is aware of this bug and fixes it)
- Fixed path translation heuristics for LoadLibrary, so explicitly loading system DLLs does not fail anymore