### PR TITLE
Various compatibility fixes for Upstate Liberty

### DIFF
--- a/src/core/folder.cpp
+++ b/src/core/folder.cpp
@@ -14,8 +14,7 @@ using namespace modloader;
 void Loader::FolderInformation::Clear()
 {
     mods.clear();
-    profiles.clear();
-    current_profile = nullptr;
+    RemoveProfiles();
 }
 
 /*
@@ -127,8 +126,9 @@ void Loader::FolderInformation::RemoveReferencesToProfile(Loader::Profile& rm)
  */
 void Loader::FolderInformation::RemoveProfiles()
 {
-    for(auto it = this->profiles.begin(); it != this->profiles.end(); )
-        it = this->profiles.erase(it);  // Profile destructor automatically cleans this->current_profile
+    for(auto& prof : this->profiles)
+        RemoveReferencesToProfile(prof);
+    this->profiles.clear();
 }
 
 /*

--- a/src/core/loader.hpp
+++ b/src/core/loader.hpp
@@ -272,7 +272,6 @@ class Loader : public modloader_t
                 {}
 
                 Profile(const Profile&) = default;
-                ~Profile();
 
                 //
                 FolderInformation& Parent() const  { return this->parent; }

--- a/src/core/profiles.cpp
+++ b/src/core/profiles.cpp
@@ -34,14 +34,6 @@ static bool MatchWildcards(const std::string& string, const Container& patterns)
 
 
 /*
- *  Profile::~Profile
- */
-Loader::Profile::~Profile()
-{
-    parent.RemoveReferencesToProfile(*this);
-}
-
-/*
  *  Profile::Clear
  *      Clears this object
  */

--- a/src/plugins/gta3/std.asi/CsInfo.cpp
+++ b/src/plugins/gta3/std.asi/CsInfo.cpp
@@ -16,18 +16,14 @@ using namespace modloader;
  *  This stores information about cleo scripts 
  */
 ThePlugin::CsInfo::CsInfo(const modloader::file* file) : file(file)
-{
-    // Do basic initial setup
-    this->bIsMission = false;                   
-    this->iVersion = CLEO_VER_NONE;
-    
-    std::string path = file->filepath();
+{    
+    const std::string path = file->filepath();
 
     // Get path used to search files when a script tries to open a file (fopen etc)
     if(IsFileInsideFolder(file->filedir(), true, "CLEO"))  // If inside a CLEO folder, use the path before it
-        this->folder = path.substr(0, GetLastPathComponent(path, 2));
+        this->translationPath = path.substr(0, GetLastPathComponent(path, 2));
     else                                        // Use this path
-        this->folder = path.substr(0, GetLastPathComponent(path, 1));
+        this->translationPath = path.substr(0, GetLastPathComponent(path, 1));
 
     // Get script attributes
     if(file->is_ext("cm"))

--- a/src/plugins/gta3/std.asi/CsInfo.cpp
+++ b/src/plugins/gta3/std.asi/CsInfo.cpp
@@ -21,9 +21,9 @@ ThePlugin::CsInfo::CsInfo(const modloader::file* file) : file(file)
 
     // Get path used to search files when a script tries to open a file (fopen etc)
     if(IsFileInsideFolder(file->filedir(), true, "CLEO"))  // If inside a CLEO folder, use the path before it
-        this->translationPath = path.substr(0, GetLastPathComponent(path, 2));
+        this->translationPath = plugin_ptr->loader->gamepath + path.substr(0, GetLastPathComponent(path, 2));
     else                                        // Use this path
-        this->translationPath = path.substr(0, GetLastPathComponent(path, 1));
+        this->translationPath = plugin_ptr->loader->gamepath + path.substr(0, GetLastPathComponent(path, 1));
 
     // Get script attributes
     if(file->is_ext("cm"))

--- a/src/plugins/gta3/std.asi/ModuleInfo.cpp
+++ b/src/plugins/gta3/std.asi/ModuleInfo.cpp
@@ -23,11 +23,11 @@ static bool ModulesWalk(uint32_t pid, F functor);
  *  Constructs a ModuleInfo object
  *  It takes a rvalue for a relative path string
  */
-ThePlugin::ModuleInfo::ModuleInfo(std::string path, const modloader::file* file, HMODULE mod) : file(file)
+ThePlugin::ModuleInfo::ModuleInfo(std::string path, const modloader::file* file, HMODULE mod)
+    : file(file), module(mod)
 {
-    size_t last = GetLastPathComponent(path);
-    bIsMainExecutable = bIsASI = bIsD3D9 = bIsMainCleo = bIsCleo = false;
-    memset(&this->hacks, 0, sizeof(hacks));
+    const size_t last = GetLastPathComponent(path);
+    size_t lastForPath = last;
     
     const char* filename = &path[last];
     
@@ -58,7 +58,18 @@ ThePlugin::ModuleInfo::ModuleInfo(std::string path, const modloader::file* file,
         }
         
         // If not a .cleo, it's an .asi plugin
-        if(!bIsCleo) bIsASI = true;
+        if(!bIsCleo)
+        {
+            bIsASI = true;
+
+            // If this ASI is inside 'scripts', 'plugins' or 'mss', we need to flag this
+            // so path translators start from the directory above it
+            const std::string dirName = GetPathComponentBack(path, 2);
+            if (!strcmp("scripts", dirName.c_str(), false) || !strcmp("plugins", dirName.c_str(), false) || !strcmp("mss", dirName.c_str(), false))
+            {
+                lastForPath = GetLastPathComponent(path, 2);
+            }
+        }
     }
     
     // Setup hacks flags
@@ -67,10 +78,10 @@ ThePlugin::ModuleInfo::ModuleInfo(std::string path, const modloader::file* file,
     {
         hacks.bRyosukeModuleName = true;
     }
-    
+
     // Setup fields
-    this->module = mod;
     this->folder = path.substr(0, last);
+    this->translationPath = path.substr(0, lastForPath);
 }
 
 

--- a/src/plugins/gta3/std.asi/ModuleInfo.cpp
+++ b/src/plugins/gta3/std.asi/ModuleInfo.cpp
@@ -80,8 +80,8 @@ ThePlugin::ModuleInfo::ModuleInfo(std::string path, const modloader::file* file,
     }
 
     // Setup fields
-    this->folder = path.substr(0, last);
-    this->translationPath = path.substr(0, lastForPath);
+    this->folder = plugin_ptr->loader->gamepath + path.substr(0, last);
+    this->translationPath = plugin_ptr->loader->gamepath + path.substr(0, lastForPath);
 }
 
 
@@ -202,7 +202,7 @@ bool ThePlugin::ModuleInfo::Load()
     if(!this->module)
     {
         // Chdir to the asi path, so it can do stuff on DllMain properly
-        scoped_chdir xdir((std::string(plugin_ptr->loader->gamepath) + this->folder).c_str());
+        scoped_chdir xdir(this->folder.c_str());
 
         // We need the fullpath into the module because of the way Windows load dlls
         // More info at: http://msdn.microsoft.com/en-us/library/windows/desktop/ms682586(v=vs.85).aspx

--- a/src/plugins/gta3/std.asi/args_translator/translator_basic.hpp
+++ b/src/plugins/gta3/std.asi/args_translator/translator_basic.hpp
@@ -163,18 +163,17 @@ struct path_translator_base
         // Size of each element in the character pool
         static const size_t pool_elem_size = MAX_PATH * sizeof(wchar_t);
 
-        bool bSetDir;                       // Call comming from gta_sa.exe:_chdir
-        bool bAbsolutePath;                 // Is translating a path with absolute path?       
+        bool bSetDir = false;                       // Call comming from gta_sa.exe:_chdir
+        bool bAbsolutePath = false;                 // Is translating a path with absolute path?       
         
         std::unique_ptr<char[]> path_pool;  // Character pool
         size_t path_pool_used;              // Size (not number of elements) used in the pool
         
-        path_translator_base* base;         // Translator
-        ModuleInfo* asi;                    // Pointer to Calling ASI module
+        path_translator_base* base = nullptr; // Translator
+        ModuleInfo* asi = nullptr;            // Pointer to Calling ASI module
         
         // Construct the information
-        CallInfo() : asi(0), base(0), bSetDir(false)
-        {}
+        CallInfo() = default;
         
         // Allocates a path in the pool. @size is the num characters the path will need.
         auto_pointer AllocPath(size_t size)

--- a/src/plugins/gta3/std.asi/args_translator/xtranslator_path.hpp
+++ b/src/plugins/gta3/std.asi/args_translator/xtranslator_path.hpp
@@ -21,26 +21,15 @@
 template<class T, class M, class F>
 inline bool  path_translator_base::CallInfo::CxBuildPath(T* p, const M& module, const char* currdir, const T*& arg, F build_path, bool bForce)
 {
-    char tmp[MAX_PATH];
-    const char* prefix = module.translationPath.c_str();
-
-    // We have to take care when CLEO is trying to open a new custom script, it will try to do so
-    // from [chdir("CLEO")] so we need to get one level back in the directory tree
-    if(asi->bIsMainCleo && base->bCreateFile && !_stricmp(currdir, "CLEO"))
-    {
-        // Cleo is probably trying to open a new custom script
-        sprintf(tmp, "..\\%s", prefix);     // Get back in the directory tree
-        prefix = tmp;                       //
-    }
-    // In case of the need of an full path, do it on the prefix
-    else if(this->bAbsolutePath)
-    {
-        sprintf(tmp, "%s%s", plugin_ptr->loader->gamepath, prefix);
-        prefix = tmp;
-    }
+    // We always want to build an absolute translated path, even if the game only requested a relative one.
+    // Two reasons for this:
+    // 1. We have to take care when CLEO is trying to open a new custom script, it will try to do so
+    //    from [chdir("CLEO")], so using an absolute path helps us avoid "undoing" it.
+    // 2. For some data files (like main.scm), the game does a [chdir("data")] ([chdir("data\scripts")] in San Andreas)
+    //    and loads the file then. Using an absolute path, we don't need to care about this.
     
     // Build the path
-    if(auto* path = build_path(p, prefix, currdir, arg))
+    if(auto* path = build_path(p, module.translationPath.c_str(), currdir, arg))
     {
         // Check if path "prefix + currdir + arg" exists, if yes, signalyze it
         if(bForce || IsPath(path))

--- a/src/plugins/gta3/std.asi/args_translator/xtranslator_path.hpp
+++ b/src/plugins/gta3/std.asi/args_translator/xtranslator_path.hpp
@@ -22,7 +22,7 @@ template<class T, class M, class F>
 inline bool  path_translator_base::CallInfo::CxBuildPath(T* p, const M& module, const char* currdir, const T*& arg, F build_path, bool bForce)
 {
     char tmp[MAX_PATH];
-    const char* prefix = module.folder.c_str();
+    const char* prefix = module.translationPath.c_str();
 
     // We have to take care when CLEO is trying to open a new custom script, it will try to do so
     // from [chdir("CLEO")] so we need to get one level back in the directory tree

--- a/src/plugins/gta3/std.asi/asi.h
+++ b/src/plugins/gta3/std.asi/asi.h
@@ -59,8 +59,8 @@ class ThePlugin : public modloader::basic_plugin
             } hacks;
             
             HMODULE module = nullptr; // The module handle
-            std::string folder;          // The folder where the asi is at, like "modloader/aaa/"
-            std::string translationPath; // The path to use for path translations. Will be one directory up from the above if the module is in 'scripts'
+            std::string folder;          // Absolute path to where the asi is at, like "modloader/aaa/"
+            std::string translationPath; // Absolute path to use for path translations. Will be one directory up from the above if the module is in 'scripts'
             std::vector<path_translator_base*> translators;
 
             
@@ -88,7 +88,7 @@ class ThePlugin : public modloader::basic_plugin
             bool        bIsMission = false;
             
             const modloader::file* file = nullptr;
-            std::string translationPath;                // e.g. "modloader/foo/"
+            std::string translationPath;                // e.g. "modloader/foo/". Absolute
             
             CsInfo(const modloader::file* file);
             static bool GetVersionFromExtension(const char* ext, char& version);

--- a/src/plugins/gta3/std.asi/asi.h
+++ b/src/plugins/gta3/std.asi/asi.h
@@ -46,20 +46,21 @@ class ThePlugin : public modloader::basic_plugin
          */
         struct ModuleInfo
         {
-            bool bIsASI;                // Is this a ASI module?
-            bool bIsD3D9;               // Is this a D3D9.dll module?
-            bool bIsMainExecutable;     // Is this the main executable? (gta_sa.exe etc)
-            bool bIsCleo;               // Is the main CLEO.asi or any .cleo plugin
-            bool bIsMainCleo;           // Is the main CLEO.asi
+            bool bIsASI = false;                // Is this a ASI module?
+            bool bIsD3D9 = false;               // Is this a D3D9.dll module?
+            bool bIsMainExecutable = false;     // Is this the main executable? (gta_sa.exe etc)
+            bool bIsCleo = false;               // Is the main CLEO.asi or any .cleo plugin
+            bool bIsMainCleo = false;           // Is the main CLEO.asi
             
             struct      // Hacks that some ASIs will need to work properly
             {
-                bool bRyosukeModuleName;
+                bool bRyosukeModuleName = false;
                 
             } hacks;
             
-            HMODULE module;         // The module handle
-            std::string folder;     // The folder where the asi is at, like "modloader/aaa/"
+            HMODULE module = nullptr; // The module handle
+            std::string folder;          // The folder where the asi is at, like "modloader/aaa/"
+            std::string translationPath; // The path to use for path translations. Will be one directory up from the above if the module is in 'scripts'
             std::vector<path_translator_base*> translators;
 
             
@@ -75,7 +76,7 @@ class ThePlugin : public modloader::basic_plugin
             path_translator_base* FindTranslatorFrom(const char* symbol, const char* libname);
 
             private:
-                const modloader::file*  file; // The module file (may be null)
+                const modloader::file*  file = nullptr; // The module file (may be null)
         };
         
         /*
@@ -83,11 +84,11 @@ class ThePlugin : public modloader::basic_plugin
          */
         struct CsInfo
         {
-            char        iVersion;
-            bool        bIsMission;
+            char        iVersion = CLEO_VER_NONE;
+            bool        bIsMission = false;
             
-            const modloader::file* file;
-            std::string folder;     // e.g. "modloader/foo/"
+            const modloader::file* file = nullptr;
+            std::string translationPath;                // e.g. "modloader/foo/"
             
             CsInfo(const modloader::file* file);
             static bool GetVersionFromExtension(const char* ext, char& version);

--- a/src/plugins/gta3/std.data/data.hpp
+++ b/src/plugins/gta3/std.data/data.hpp
@@ -310,7 +310,7 @@ class DataPlugin : public modloader::basic_plugin
 
             // Replaces standard OnHook with this one, which just makes the call no setfile (since many files)
             // This gets called during InstallFile/ReinstallFile/UninstallFile
-            ov.MakeCallForAllDetours();
+            ov.MakeCallForAllDetours<Detours...>();
 
             AddBehv(hash, true);
             return ov;
@@ -335,31 +335,24 @@ class DataPlugin : public modloader::basic_plugin
 
         
 
-        template<class detour_type>
+        template<class... Detours>
         modloader::file_overrider& AddIplOverrider(std::string fsfile, bool unique, bool samefile, bool complete_path,
                                               const modloader::file_overrider::params& params)
         {
             fsfile = modloader::NormalizePath(std::move(fsfile));
             auto hash = modloader::hash(fsfile);
 
+            auto on_transform = std::bind(&DataPlugin::GetIplFile, this, _1, fsfile, unique, samefile, complete_path);
             auto& ov = ovmap.emplace(std::piecewise_construct,
                 std::forward_as_tuple(hash),
-                std::forward_as_tuple(tag_detour, params, detour_type())
+                std::forward_as_tuple(tag_detour, params, std::forward_as_tuple(Detours(on_transform)...))
                 ).first->second;
-
-            for(size_t i = 0; i < ov.NumInjections(); ++i)
-            {
-                // Merges data whenever necessary to open this file. Caching can happen.
-                auto& d = static_cast<detour_type&>(ov.GetInjection(i));
-                d.OnTransform(std::bind(&DataPlugin::GetIplFile, this, _1, fsfile, unique, samefile, complete_path));
-            }
 
             // Replaces standard OnHook with this one, which just makes the call no setfile (since many files)
             // This gets called during InstallFile/ReinstallFile/UninstallFile
             ov.OnHook([&ov](const modloader::file*)
             {
-                for(size_t i = 0; i < ov.NumInjections(); ++i)
-                    static_cast<detour_type&>(ov.GetInjection(i)).make_call();
+                ov.MakeCallForAllDetours<Detours...>();
             });
 
             AddBehv(hash, true);

--- a/src/plugins/gta3/std.data/data_traits/ipl.cpp
+++ b/src/plugins/gta3/std.data/data_traits/ipl.cpp
@@ -15,10 +15,26 @@ struct ipl_traits
     };
 };
 
+struct mapzone_traits
+{
+    struct dtraits : modloader::dtraits::OpenFile
+    {
+        static const char* what() { return "mapzone"; }
+    };
+};
+
 using OpenSceneDetour = modloader::OpenFileDetour<0x5B871A, ipl_traits::dtraits>;
+using OpenMapZoneDetour = modloader::OpenFileDetour<xIII(0x478570), mapzone_traits::dtraits>;
 
 using namespace std::placeholders;
 static auto xinit = initializer([](DataPlugin* plugin_ptr)
 {
-    plugin_ptr->AddIplOverrider<OpenSceneDetour>(ipl_merger_name, false, false, true, no_reinstall);
+    if (gvm.IsIII())
+    {
+        plugin_ptr->AddIplOverrider<OpenSceneDetour, OpenMapZoneDetour>(ipl_merger_name, false, false, true, no_reinstall);
+    }
+    else
+    {
+        plugin_ptr->AddIplOverrider<OpenSceneDetour>(ipl_merger_name, false, false, true, no_reinstall);
+    }
 });

--- a/src/plugins/gta3/std.scm/scm.cpp
+++ b/src/plugins/gta3/std.scm/scm.cpp
@@ -14,7 +14,10 @@ using namespace modloader;
 class ScmPlugin : public modloader::basic_plugin
 {
     private:
-        file_overrider overrider;
+        std::map<uint32_t, const modloader::file*> scm; // SCM Files Map<hash, file>
+
+        OpenFileDetour<0x468EC9> scm_d1;                // CTheScripts::Init detour
+        OpenFileDetour<0x489A4A> scm_d2;                // CRunningScript::ProcessCommands1000To1099 detour
 
     public:
         const info& GetInfo();
@@ -52,8 +55,17 @@ bool ScmPlugin::OnStartup()
 {
     if(gvm.IsIII() || gvm.IsVC() || gvm.IsSA())
     {
-        this->overrider.SetParams(file_overrider::params(true, true, true, true));
-        this->overrider.SetFileDetour(OpenFileDetour<0x468EC9>(), OpenFileDetour<0x489A4A>());
+        // Returns the overriden scm file path (relative to gamedir)
+        auto transformer = [this](std::string filename)
+        {
+            auto it = scm.find(modloader::hash(&filename[GetLastPathComponent(filename)], ::tolower));
+            return std::string(it != scm.end()? it->second->filepath() : "");
+        };
+
+        this->scm_d1.make_call();
+        this->scm_d1.OnTransform(transformer);
+        this->scm_d2.make_call();
+        this->scm_d2.OnTransform(transformer);
         return true;
     }
     return false;
@@ -75,8 +87,7 @@ bool ScmPlugin::OnShutdown()
  */
 int ScmPlugin::GetBehaviour(modloader::file& file)
 {
-    static const auto main_scm = modloader::hash("main.scm");
-    if(!file.is_dir() && file.hash == main_scm)
+    if(!file.is_dir() && file.is_ext("scm"))
     {
         file.behaviour = file.hash;
         return MODLOADER_BEHAVIOUR_YES;
@@ -90,7 +101,8 @@ int ScmPlugin::GetBehaviour(modloader::file& file)
  */
 bool ScmPlugin::InstallFile(const modloader::file& file)
 {
-    return overrider.InstallFile(file);
+    this->scm[file.hash] = &file;
+    return true;
 }
 
 /*
@@ -99,7 +111,7 @@ bool ScmPlugin::InstallFile(const modloader::file& file)
  */
 bool ScmPlugin::ReinstallFile(const modloader::file& file)
 {
-    return overrider.ReinstallFile();
+    return InstallFile(file);
 }
 
 /*
@@ -108,5 +120,6 @@ bool ScmPlugin::ReinstallFile(const modloader::file& file)
  */
 bool ScmPlugin::UninstallFile(const modloader::file& file)
 {
-    return overrider.UninstallFile();
+    this->scm.erase(file.hash);
+    return true;
 }

--- a/src/translator/gta3/3/10.hpp
+++ b/src/translator/gta3/3/10.hpp
@@ -241,6 +241,7 @@ static void III_10(std::map<memory_pointer_raw, memory_pointer_raw>& map)
         map[xVc(0x527570)] = 0x4E9870; // _ZN4CPed13LoadFightDataEv
         map[xVc(0x527590)] = 0x4E9890; // call    _ZN8CFileMgr12LoadTextFileEPKcPhi     ; @CPed::LoadFightData
         map[xIII(0x524EDA)] = 0x524EDA;  // call    _ZN8CFileMgr8OpenFileEPKcS1_        ; "data/cullzone.dat"
+        map[xIII(0x478570)] = 0x478570; // call     _ZN8CFileMgr8OpenFileEPKcS1_        ; @CFileLoader::LoadMapZones
 
         map[xVc(0x5B220A)] = 0x54B84E; // call    _ZN6CPlane8LoadPathEPKcRiRfb  ; "flight.dat"
         map[xVc(0x5B2475)] = 0x54BB0A; // call    _ZN6CPlane8LoadPathEPKcRiRfb  ; "flight2.dat"


### PR DESCRIPTION
This PR fixes a set of bugs and missing features in Modloader that prevented **Upstate Liberty** for GTA III from loading correctly.

1. Arbitrarily named script files can now be loaded. This makes `main_d.scm` placed in a Modloader directory loadable through **gtadebug**.
2. ASI files installed in `scripts`, `plugins` and `mss` now translate paths relatively to their parent path. The reasoning is that the path above any of the three is most likely the "mod root directory", and so the assumption is that files should load relatively to those. This fixes a case where the following mod structure worked standalone, but failed with Modloader:
   ```
   mod_dir\
      scripts\
         MyPlugin.asi <--- loads "data\myFile.dat"
      data\
         myFile.dat
   ```
3. Path translations now **always** use an absolute path to the Modloader directory. This has multiple benefits:
   1. Path translation function is simplified greatly.
   2. CLEO script special-case has been removed, as there is no need to go "up" one directory anymore.
   3. Files loaded by the game through a `chdir("data")` (or similar) now work correctly. In the current version of Modloader, that current directory was correctly reconstructed inside the mod directory, but the actual `chdir` was **not** countered, so the game tried to load files from paths like:
   ```gta3\data\modloader\mod_dir\data\file.dat```
   By using absolute paths, Modloader doesn't need to care about this `chdir` at all, and there is no need to try and traverse the directory back.
4. Support for overriding `MAPZONE` definitions (`map.zon` file) has been added. This III-exclusive DAT definition has an identical syntax to `IPL`, so the IPL overrider was extended to also support this.
5. An exit crash on freeing Profiles was fixed. I suspect it never crashed with older VS compilers, but with the one I used now, an attempt to iterate `this->profiles` in the middle of a `this->profiles.clear()` call consistently crashed. I untangled the code so the destructors of `Profile` don't touch this container at all, and instead it's the container's responsibility to unregister everything up front.

This set of fixes makes Upstate Liberty fully loadable from Modloader - just extract the mod archive to `modloader\` and go.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ab056592-4655-48c1-b250-9f2997cbd8c0" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/982325b7-b9de-410a-a593-f0ebb9a7eb62" />


Fixes #123. Fixes #127. 